### PR TITLE
Add boost::date_time to required components

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -10,7 +10,7 @@ find_package(catkin REQUIRED COMPONENTS
     diagnostic_updater
 )
 
-find_package(Boost REQUIRED COMPONENTS thread)
+find_package(Boost REQUIRED COMPONENTS thread date_time)
 
 # Generate messages and services
 add_message_files(FILES


### PR DESCRIPTION
This fixes an issue when compiling the Vicon SDK introduced by the recently merged PR #29 